### PR TITLE
Harden tunnel I/O paths against buffer overruns and async failures

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.5)
 project(termtunnel C)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_C_STANDARD 11)
@@ -82,4 +82,3 @@ ENDIF()
 if (LINUX)
     target_link_libraries(termtunnel PUBLIC "-static")
 endif()
-

--- a/src/agent.c
+++ b/src/agent.c
@@ -8,6 +8,7 @@
 
 #include <fcntl.h>
 #include <stdbool.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -104,9 +105,18 @@ void agent_set_stdin_noecho() {
 void write_frame_to_server(char *data, int data_size) {
   int len_result;
   char *tmp = (char *)malloc(data_size + 1);
+  if (tmp == NULL) {
+    log_error("malloc frame buffer failed");
+    return;
+  }
   memcpy(tmp, data, data_size);
   tmp[data_size] = '!';
   char *result = green_encode(tmp, data_size + 1, &len_result);
+  if (result == NULL) {
+    free(tmp);
+    log_error("green_encode failed");
+    return;
+  }
   agent_write_data_to_server(result, len_result, true);
   free(tmp);
 }
@@ -148,19 +158,53 @@ void agent_read_stdin(uv_stream_t *stream, ssize_t nread, const uv_buf_t *buf) {
     }
 
     static char *data = NULL;
+    static size_t data_cap = 0;
     if (data == NULL) {
-      data = (char *)malloc(2 * max_suggested_size);
+      data_cap = 2 * (size_t)max_suggested_size;
+      data = (char *)malloc(data_cap);
+      if (data == NULL) {
+        log_error("malloc stdin buffer failed");
+        if (buf->base) {
+          free(buf->base);
+        }
+        return;
+      }
     }
     static int data_size = 0;
     CHECK(nread <= max_suggested_size, "nread<=max_suggested_size");
+    if ((size_t)data_size + (size_t)nread > data_cap) {
+      size_t need = (size_t)data_size + (size_t)nread;
+      size_t new_cap = data_cap;
+      while (new_cap < need) {
+        if (new_cap > SIZE_MAX / 2) {
+          log_error("stdin buffer overflow risk");
+          uv_read_stop(stream);
+          if (buf->base) {
+            free(buf->base);
+          }
+          return;
+        }
+        new_cap *= 2;
+      }
+      char *new_data = realloc(data, new_cap);
+      if (new_data == NULL) {
+        log_error("realloc stdin buffer failed");
+        uv_read_stop(stream);
+        if (buf->base) {
+          free(buf->base);
+        }
+        return;
+      }
+      data = new_data;
+      data_cap = new_cap;
+    }
     memcpy(data + data_size, buf->base, nread);
     data_size += nread;
-    CHECK(data_size <= 2 * max_suggested_size, "data_size>=2*max_suggested_size");
 
     int used_data_size = process_stdin(data, data_size);
     int unused_data_size = data_size - used_data_size;
     if (unused_data_size > 0) {
-      CHECK(unused_data_size < max_suggested_size, "erorr");
+      CHECK((size_t)unused_data_size <= data_cap, "unused_data_size overflow");
       memmove(data, data + used_data_size, unused_data_size);
     }
     data_size = unused_data_size;
@@ -175,15 +219,26 @@ int write_binary_to_server(const char *buf, size_t size) {
   // base64
 
   size_t elen = 0;
-  char *ebuf = base64_encode(buf, size, &elen);
+  unsigned char *ebuf =
+      base64_encode((const unsigned char *)buf, size, &elen);
+  if (ebuf == NULL) {
+    log_error("base64_encode failed");
+    return -1;
+  }
 
   char *tmp = (char *)malloc(elen + 1);
+  if (tmp == NULL) {
+    free(ebuf);
+    log_error("malloc base64 buffer failed");
+    return -1;
+  }
   tmp[0] = 'B';
-  memcpy(tmp + 1, ebuf, elen);
+  memcpy(tmp + 1, (const char *)ebuf, elen);
   write_frame_to_server(tmp, elen + 1);
 
   free(tmp);
   free(ebuf);
+  return 0;
 }
 int agent_handle_binary(char *buf, int size);
 
@@ -213,13 +268,15 @@ int agent_process_frame(char *str_data, int data_size) {
   // base64 type
   if (data_size > 1 && str_data[0] == 'B') {
     size_t result_len = 0;
-    char *result = base64_decode(str_data + 1, data_size - 1, &result_len);
+    unsigned char *result =
+        base64_decode((const unsigned char *)(str_data + 1), data_size - 1,
+                      &result_len);
     if (result_len == 0) {
       // TODO!
       log_error("found a error base64 [%*s]\n", data_size - 1, str_data + 1);
       return 0;
     }
-    agent_handle_binary(result, result_len);
+    agent_handle_binary((char *)result, result_len);
     free(result);
     return 0;
   } else {
@@ -242,17 +299,36 @@ void agent_write_data_to_server(char *buf, size_t s, bool autofree) {
   pending_send++;
   uv_write_t *req1 = malloc(sizeof(uv_write_t));
   uv_buf_t *b = malloc(sizeof(uv_buf_t));
+  if (req1 == NULL || b == NULL) {
+    free(req1);
+    free(b);
+    if (autofree) {
+      free(buf);
+    }
+    pending_send--;
+    log_error("malloc uv write request failed");
+    return;
+  }
   b->base = buf;
   b->len = s;
   req1->data = b;
   if (autofree) {
     int ret = uv_write(req1, (uv_stream_t *)&agent_stdout_tty, b, 1,
                        write_cb_with_free);
-    // assert(ret==0);
+    if (ret != 0) {
+      pending_send--;
+      free(((uv_buf_t *)(req1->data))->base);
+      free(req1->data);
+      free(req1);
+    }
   } else {
     int ret = uv_write(req1, (uv_stream_t *)&agent_stdout_tty, b, 1,
                        write_cb_without_free);
-    // assert(ret==0);
+    if (ret != 0) {
+      pending_send--;
+      free(req1->data);
+      free(req1);
+    }
   }
 }
 
@@ -291,13 +367,33 @@ void agent(int argc, char** argv) {
 
   static uv_timer_t timer_watcher;
   uv_loop_t *loop = uv_default_loop();
-  uv_timer_init(loop, &timer_watcher);
-  uv_timer_start(&timer_watcher, agent_timer_callback, TIMEOUT_MS, REPEAT_MS);
+  int rc = uv_timer_init(loop, &timer_watcher);
+  if (rc != 0) {
+    log_error("uv_timer_init failed: %d", rc);
+    exit(EXIT_FAILURE);
+  }
+  rc = uv_timer_start(&timer_watcher, agent_timer_callback, TIMEOUT_MS, REPEAT_MS);
+  if (rc != 0) {
+    log_error("uv_timer_start failed: %d", rc);
+    exit(EXIT_FAILURE);
+  }
 
-  uv_tty_init(loop, &agent_stdin_tty, STDIN_FILENO, 1);
-  uv_tty_init(loop, &agent_stdout_tty, STDOUT_FILENO, 0);
-  uv_read_start((uv_stream_t *)&agent_stdin_tty, alloc_buffer,
-                agent_read_stdin);
+  rc = uv_tty_init(loop, &agent_stdin_tty, STDIN_FILENO, 1);
+  if (rc != 0) {
+    log_error("uv_tty_init stdin failed: %d", rc);
+    exit(EXIT_FAILURE);
+  }
+  rc = uv_tty_init(loop, &agent_stdout_tty, STDOUT_FILENO, 0);
+  if (rc != 0) {
+    log_error("uv_tty_init stdout failed: %d", rc);
+    exit(EXIT_FAILURE);
+  }
+  rc = uv_read_start((uv_stream_t *)&agent_stdin_tty, alloc_buffer,
+                     agent_read_stdin);
+  if (rc != 0) {
+    log_error("uv_read_start agent stdin failed: %d", rc);
+    exit(EXIT_FAILURE);
+  }
 
   libuv_add_vnet_notify();
   vnet_init(vnet_notify_to_libuv);

--- a/src/agentcall.c
+++ b/src/agentcall.c
@@ -31,6 +31,7 @@
 #include "portforward.h"
 
 static uint16_t agentcall_service_port = 300;
+static const int32_t kMaxOneshotArgc = 1024;
 
 typedef struct thread_arg_pass_t {
   char *strbuf;
@@ -38,7 +39,7 @@ typedef struct thread_arg_pass_t {
 } thread_arg_pass_t;
 
 static void agentcall_server_request(void *p) {
-  int sd = (int)p;
+  int sd = (int)(intptr_t)p;
   vnet_setsocketdefaultopt(sd);
   char recv_buf[READ_CHUNK_SIZE];
   int n, nwrote;
@@ -58,8 +59,13 @@ static void agentcall_server_request(void *p) {
     char remote_host[IPV4_AND_IPV6_MAX_LENGTH];
     uint16_t local_port;
     uint16_t remote_port;
-    sscanf(recv_buf, "%64[^:]:%hu:%64[^:]:%hu",
-             &local_host, &local_port, &remote_host, &remote_port);
+    int parsed = sscanf(recv_buf, "%63[^:]:%hu:%63[^:]:%hu", local_host,
+                        &local_port, remote_host, &remote_port);
+    if (parsed != 4) {
+      log_error("invalid METHOD_CALL_FORWARD_STATIC payload: %s", recv_buf);
+      lwip_close(sd);
+      return;
+    }
     log_info("agent will bind %s:%hu, write to %s:%hu",
              local_host, local_port, remote_host, remote_port);
     portforward_static_start(local_host, local_port, remote_host,
@@ -108,10 +114,23 @@ int bootstrap_get_args(void * _) {
   vnet_send(nfd, &method, sizeof(int32_t));
   vnet_send(nfd, "", 1);
   int32_t argc;
-  vnet_readn(nfd, &argc, sizeof(int32_t));
+  if (vnet_readn(nfd, &argc, sizeof(int32_t)) == 0) {
+    vnet_close(nfd);
+    return 0;
+  }
+  if (argc < 0 || argc > kMaxOneshotArgc) {
+    log_error("invalid argc from agent: %d", argc);
+    vnet_close(nfd);
+    return 0;
+  }
   log_debug("count of arg %d", argc);
   g_oneshot_argc = argc;
-  g_oneshot_argv = malloc(argc * sizeof(char*));
+  g_oneshot_argv = malloc(argc * sizeof(char *));
+  if (g_oneshot_argv == NULL && argc > 0) {
+    log_error("malloc g_oneshot_argv failed");
+    vnet_close(nfd);
+    return 0;
+  }
   char recv_buf[READ_CHUNK_SIZE];
   for (int i=0; i < argc; i++) {
     if (vnet_readstring(nfd, recv_buf, READ_CHUNK_SIZE) == 0) {

--- a/src/entry.c
+++ b/src/entry.c
@@ -72,7 +72,7 @@ static void on_resize(int signum) {
 }
 
 
-void cli_loop(int in, int out, int argc, const char *argv[]) {
+void cli_loop(int in, int out, int argc, char *argv[]) {
   repl_init();
   while (true) {
     interact_run(in, out);
@@ -87,7 +87,7 @@ void cli_loop(int in, int out, int argc, const char *argv[]) {
   }
 }
 
-void cli(int argc, const char *argv[], pid_t child_pid) {
+void cli(int argc, char *argv[], pid_t child_pid) {
   set_client_process();
   // Close write end
   close(in_fd[1]);
@@ -100,7 +100,7 @@ void cli(int argc, const char *argv[], pid_t child_pid) {
   exit(EXIT_SUCCESS);
 }
 
-int main(int argc, const char *argv[]) {
+int main(int argc, char *argv[]) {
   signal(SIGTTIN, SIG_IGN);
   signal(SIGTTOU, SIG_IGN);
   signal(SIGPIPE, SIG_IGN);

--- a/src/fileexchange.c
+++ b/src/fileexchange.c
@@ -6,6 +6,7 @@
  */
 
 #include <fcntl.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -36,7 +37,7 @@ typedef struct path_exchange {
 } path_exchange_t;
 
 static int file_receiver_request(void *p) {
-  int sd = (int)p;
+  int sd = (int)(intptr_t)p;
   vnet_setsocketdefaultopt(sd);
   char recv_buf[READ_CHUNK_SIZE];
   int n, nwrote;
@@ -76,7 +77,7 @@ int file_receiver_start() {
 }
 
 static int file_sender_request(void *p) {
-  int sd = (int)p;
+  int sd = (int)(intptr_t)p;
   vnet_setsocketdefaultopt(sd);
   char recv_buf[READ_CHUNK_SIZE];
   int n, nwrote;
@@ -155,8 +156,18 @@ static int file_send_request(path_exchange_t *pe) {
 int file_send_start(char *src_path, char *dst_path) {
   log_info("file_send_start1");
   path_exchange_t *pe = (path_exchange_t *)malloc(sizeof(path_exchange_t));
-  strcpy(pe->src_path, src_path);
-  strcpy(pe->dst_path, dst_path);
+  if (pe == NULL) {
+    log_error("malloc path_exchange_t failed");
+    return -1;
+  }
+  if (snprintf(pe->src_path, sizeof(pe->src_path), "%s", src_path) >=
+          (int)sizeof(pe->src_path) ||
+      snprintf(pe->dst_path, sizeof(pe->dst_path), "%s", dst_path) >=
+          (int)sizeof(pe->dst_path)) {
+    log_error("file path too long");
+    free(pe);
+    return -1;
+  }
   // TODO
   // if (stat(src_path, NULL)==0){
   // pe->exchange_notify->data=(void*)-1;
@@ -214,8 +225,18 @@ static int file_recv_request(path_exchange_t *pe) {
 
 int file_recv_start(char *src_path, char *dst_path) {
   path_exchange_t *pe = (path_exchange_t *)malloc(sizeof(path_exchange_t));
-  strcpy(pe->src_path, src_path);
-  strcpy(pe->dst_path, dst_path);
+  if (pe == NULL) {
+    log_error("malloc path_exchange_t failed");
+    return -1;
+  }
+  if (snprintf(pe->src_path, sizeof(pe->src_path), "%s", src_path) >=
+          (int)sizeof(pe->src_path) ||
+      snprintf(pe->dst_path, sizeof(pe->dst_path), "%s", dst_path) >=
+          (int)sizeof(pe->dst_path)) {
+    log_error("file path too long");
+    free(pe);
+    return -1;
+  }
   log_debug("file_recv_start");
   sys_thread_new("file_recv", (lwip_thread_fn)file_recv_request, (void *)pe,
                  DEFAULT_THREAD_STACKSIZE, DEFAULT_THREAD_PRIO);

--- a/src/fileexchange.h
+++ b/src/fileexchange.h
@@ -7,10 +7,12 @@
 
 #ifndef TERMTUNNEL_FILEEXCHANGE_H
 #define TERMTUNNEL_FILEEXCHANGE_H
-int file_send_start();
-int file_receiver_start();
+#include <stdint.h>
 
-int file_recv_start();
-int file_sender_start();
+int file_send_start(char *src_path, char *dst_path);
+int file_receiver_start(void);
+
+int file_recv_start(char *src_path, char *dst_path);
+int file_sender_start(void);
 
 #endif

--- a/src/pipe.c
+++ b/src/pipe.c
@@ -135,7 +135,16 @@ void uvloop_process_income(uv_async_t *handle) {
 
 int vnet_notify_to_libuv(char *buf, size_t size) {
   frame_data *f = (frame_data *)malloc(sizeof(frame_data));
+  if (f == NULL) {
+    log_error("malloc frame_data failed");
+    return -1;
+  }
   f->buf = memdup(buf, size);
+  if (f->buf == NULL) {
+    free(f);
+    log_error("memdup frame_data failed");
+    return -1;
+  }
   f->len = size;
   queue_put(q, f);
   // log_info("add queue");
@@ -154,6 +163,11 @@ int libuv_add_vnet_notify() {
   data_income_notify.data = (void*)1;
   int r = uv_async_init(uv_default_loop(), &data_income_notify,
                         uvloop_process_income);
+  if (r != 0) {
+    added = false;
+    log_error("uv_async_init data_income_notify failed: %d", r);
+    return -1;
+  }
   log_info("libuv_add_vnet_notify %d", r);
 
   return 0;
@@ -195,14 +209,24 @@ static void write_cb_without_free(uv_write_t *req, int status) {
   free(req);
 }
 
-static void comm_write_data_to_cli(char *buf, size_t s, bool autofree) {
+static void comm_write_data_to_cli(void *buf, size_t s, bool autofree) {
   pending_send++;
   if (pending_send > TTY_WATERMARK) {
-    uv_read_stop(&tty);
+    uv_read_stop((uv_stream_t *)&tty);
   }
   uv_write_t *req1 = malloc(sizeof(uv_write_t));
   uv_buf_t *b = malloc(sizeof(uv_buf_t));
-  b->base = buf;
+  if (req1 == NULL || b == NULL) {
+    free(req1);
+    free(b);
+    if (autofree) {
+      free(buf);
+    }
+    pending_send--;
+    log_error("malloc uv write buffer failed");
+    return;
+  }
+  b->base = (char *)buf;
   b->len = s;
   req1->data = b;
   if (autofree) {
@@ -216,7 +240,7 @@ static void comm_write_data_to_cli(char *buf, size_t s, bool autofree) {
   }
 }
 
-void comm_write_static_packet_to_cli(int64_t type, char *buf, size_t s) {
+void comm_write_static_packet_to_cli(int64_t type, void *buf, size_t s) {
   int64_t *size = (int64_t *)malloc(sizeof(int64_t));  //可能不行
   *size = s;
   comm_write_data_to_cli(size, sizeof(int64_t), true);
@@ -226,7 +250,7 @@ void comm_write_static_packet_to_cli(int64_t type, char *buf, size_t s) {
   comm_write_data_to_cli(buf, s, false);
 }
 
-void comm_write_packet_to_cli(int64_t type, char *buf, size_t s) {
+void comm_write_packet_to_cli(int64_t type, void *buf, size_t s) {
   int64_t *size = (int64_t *)malloc(sizeof(int64_t));  //可能不行
   *size = s;
   comm_write_data_to_cli(size, sizeof(int64_t), true);
@@ -238,6 +262,7 @@ void comm_write_packet_to_cli(int64_t type, char *buf, size_t s) {
 
 ssize_t parser(char *buf, ssize_t nread) {
   CHECK(nread > 0, "nread > 0");
+  const int64_t kMaxPacketPayloadSize = 64 * 1024 * 1024;
   // state machine
   static int expect_content = 0;
   static int expect_content_len = 0;
@@ -253,7 +278,15 @@ ssize_t parser(char *buf, ssize_t nread) {
   }
   if (queue_size < nread + queue_valid_size) {
     int new_size = 2 * (queue_valid_size + nread);
-    queue = realloc(queue, new_size);
+    char *new_queue = realloc(queue, new_size);
+    if (new_queue == NULL) {
+      log_error("parser realloc failed");
+      expect_content = 0;
+      expect_content_len = 0;
+      queue_valid_size = 0;
+      return -1;
+    }
+    queue = new_queue;
     queue_size = new_size;
   }
 
@@ -275,8 +308,23 @@ ssize_t parser(char *buf, ssize_t nread) {
       if ((queue_valid_size - ptr) < sizeof(int64_t)) {
         break;
       }
-      expect_content_len =
-          (*((int64_t *)(queue + ptr))) + sizeof(int64_t);  // add type
+      int64_t payload_size = 0;
+      memcpy(&payload_size, queue + ptr, sizeof(payload_size));
+      if (payload_size < 0 || payload_size > kMaxPacketPayloadSize) {
+        log_error("invalid packet payload size: %lld", payload_size);
+        expect_content = 0;
+        expect_content_len = 0;
+        queue_valid_size = 0;
+        return -1;
+      }
+      if (payload_size > INT_MAX - (int64_t)sizeof(int64_t)) {
+        log_error("packet payload too large for parser: %lld", payload_size);
+        expect_content = 0;
+        expect_content_len = 0;
+        queue_valid_size = 0;
+        return -1;
+      }
+      expect_content_len = (int)(payload_size + sizeof(int64_t));  // add type
       expect_content = 1;
       ptr += sizeof(int64_t);
     }
@@ -371,7 +419,12 @@ static void common_read_tty(uv_stream_t *stream, ssize_t nread,
 }
 
 void find_a_packet(char *buf, ssize_t len) {
-  int64_t type = *((int64_t *)buf);
+  if (len < (ssize_t)sizeof(int64_t)) {
+    log_error("invalid packet len: %zd", len);
+    return;
+  }
+  int64_t type = 0;
+  memcpy(&type, buf, sizeof(type));
   server_handle_client_packet(type, buf + sizeof(int64_t),
                               len - sizeof(int64_t));
 }
@@ -407,24 +460,56 @@ static int pty_nonblock(int fd) {
   return fcntl(fd, F_SETFL, flags | O_NONBLOCK);
 }
 
-void background_loop(int in, int out, int argc, const char *argv[]) {
+void background_loop(int in, int out, int argc, char *argv[]) {
   static uv_timer_t timer_watcher;
   uv_loop_t *loop = uv_default_loop();
-  uv_timer_init(loop, &timer_watcher);
-  uv_timer_start(&timer_watcher, timer_callback, TIMEOUT_MS, REPEAT_MS);
+  int r = uv_timer_init(loop, &timer_watcher);
+  if (r != 0) {
+    log_error("uv_timer_init failed: %d", r);
+    return;
+  }
+  r = uv_timer_start(&timer_watcher, timer_callback, TIMEOUT_MS, REPEAT_MS);
+  if (r != 0) {
+    log_error("uv_timer_start failed: %d", r);
+    return;
+  }
 
-  uv_pipe_init(loop, &in_pipe, 0);
-  uv_pipe_init(loop, &out_pipe, 0);
+  r = uv_pipe_init(loop, &in_pipe, 0);
+  if (r != 0) {
+    log_error("uv_pipe_init in_pipe failed: %d", r);
+    return;
+  }
+  r = uv_pipe_init(loop, &out_pipe, 0);
+  if (r != 0) {
+    log_error("uv_pipe_init out_pipe failed: %d", r);
+    return;
+  }
   log_info("in:%d out:%d", in, out);
-  uv_pipe_open(&in_pipe, in);
-  uv_pipe_open(&out_pipe, out);
+  r = uv_pipe_open(&in_pipe, in);
+  if (r != 0) {
+    log_error("uv_pipe_open in_pipe failed: %d", r);
+    return;
+  }
+  r = uv_pipe_open(&out_pipe, out);
+  if (r != 0) {
+    log_error("uv_pipe_open out_pipe failed: %d", r);
+    return;
+  }
   write_client_pipe = &out_pipe;
-  uv_read_start((uv_stream_t *)&in_pipe, alloc_buffer,
-                common_read_data_from_cli);
+  r = uv_read_start((uv_stream_t *)&in_pipe, alloc_buffer,
+                    common_read_data_from_cli);
+  if (r != 0) {
+    log_error("uv_read_start in_pipe failed: %d", r);
+    return;
+  }
   const int UV_HANDLE_BLOCKING_WRITES = 0x00100000;
 
   int fd = get_pty_fd();
-  uv_tty_init(loop, &tty, fd, 1);
+  r = uv_tty_init(loop, &tty, fd, 1);
+  if (r != 0) {
+    log_error("uv_tty_init failed: %d", r);
+    return;
+  }
 
   pty_nonblock(fd);
   tty.flags &= ~UV_HANDLE_BLOCKING_WRITES;
@@ -432,7 +517,11 @@ void background_loop(int in, int out, int argc, const char *argv[]) {
   // uv_stream_set_blocking(write_client_pipe, true);
   //  uv_tty_set_mode(&tty, UV_TTY_MODE_NORMAL);
 
-  uv_read_start((uv_stream_t *)&tty, alloc_buffer, common_read_tty);
+  r = uv_read_start((uv_stream_t *)&tty, alloc_buffer, common_read_tty);
+  if (r != 0) {
+    log_error("uv_read_start tty failed: %d", r);
+    return;
+  }
   log_info("server6");
   // uv_prepare_t pp;
   // uv_prepare_init(loop, &pp);
@@ -445,7 +534,7 @@ void background_loop(int in, int out, int argc, const char *argv[]) {
 // PASS
 void send_exit_message(uv_async_t *handle) {
   // uv_msg_t *socket = (uv_msg_t *)handle->data;
-  int exitcode = (int)handle->data;
+  int exitcode = (int)(intptr_t)handle->data;
   comm_write_static_packet_to_cli(COMMAND_CMD_EXIT, &exitcode, sizeof(int));
   exiting = true;
   //free(handle); // TODO
@@ -454,18 +543,26 @@ void send_exit_message(uv_async_t *handle) {
 int pty_process_on_exit(int exitcode) {
   // TODO 模拟信号错误
   // tell client our exitcode.
-  async_process_exit->data = (void*)exitcode;
+  async_process_exit->data = (void *)(intptr_t)exitcode;
   uv_async_send(async_process_exit);
   return 0;
 }
 
-void server(int argc, const char *argv[]) {
+void server(int argc, char *argv[]) {
   // Close read end
   log_info("server");
   set_server_process();
   uv_loop_t *loop = uv_default_loop();
   async_process_exit = (uv_async_t *)malloc(sizeof(uv_async_t));
-  uv_async_init(loop, async_process_exit, send_exit_message);
+  if (async_process_exit == NULL) {
+    log_error("malloc async_process_exit failed");
+    exit(EXIT_FAILURE);
+  }
+  int rc = uv_async_init(loop, async_process_exit, send_exit_message);
+  if (rc != 0) {
+    log_error("uv_async_init async_process_exit failed: %d", rc);
+    exit(EXIT_FAILURE);
+  }
   pty_run(argc, argv, pty_process_on_exit);
   // close(1);
   // close(0);  //TODO linux 可以close，但是mac 关闭后会导致 libuv 异常 exit
@@ -485,45 +582,96 @@ void server(int argc, const char *argv[]) {
 void send_data_to_agent(char *buf, size_t size) {
   uv_write_t *req1 = malloc(sizeof(uv_write_t));
   uv_buf_t *b = malloc(sizeof(uv_buf_t));
-  size_t elen;
+  if (req1 == NULL || b == NULL) {
+    free(req1);
+    free(b);
+    log_error("malloc send_data_to_agent req failed");
+    return;
+  }
   char *buf_tmp = (char *)malloc(size + 2);
+  if (buf_tmp == NULL) {
+    free(req1);
+    free(b);
+    log_error("malloc send_data_to_agent buffer failed");
+    return;
+  }
   memcpy(buf_tmp, buf, size);
   memcpy(buf_tmp + size, "!\n", 2);
   b->base = buf_tmp;
   b->len = size + 2;
   req1->data = b;
-  uv_write(req1, (uv_stream_t *)&tty, b, 1, tty_write_cb_with_free);
+  int ret = uv_write(req1, (uv_stream_t *)&tty, b, 1, tty_write_cb_with_free);
+  if (ret != 0) {
+    free(((uv_buf_t *)(req1->data))->base);
+    free(req1->data);
+    free(req1);
+  }
 }
 
 void send_base64binary_to_agent(const char *buf, size_t size) {
   size_t elen = 0;
-  char *ebuf = base64_encode(buf, size, &elen);
+  unsigned char *ebuf =
+      base64_encode((const unsigned char *)buf, size, &elen);
+  if (ebuf == NULL) {
+    log_error("base64_encode failed");
+    return;
+  }
   //log_debug("server will write base64 %*s(%d)", elen, ebuf, elen);
   char *tmp = (char *)malloc(elen + 1);
+  if (tmp == NULL) {
+    free(ebuf);
+    log_error("malloc send_base64 buffer failed");
+    return;
+  }
   tmp[0] = 'B';
-  memcpy(tmp + 1, ebuf, elen);
+  memcpy(tmp + 1, (const char *)ebuf, elen);
   send_data_to_agent(tmp, elen + 1);
   free(tmp);
   free(ebuf);
 }
 
 int termtunnel_notify(void* s) {
-  uv_async_send(s);
+  return uv_async_send(s);
 }
 
 void get_args_done_callback(uv_async_t *a){
-  char* buf = malloc(READ_CHUNK_SIZE);
-  memcpy(buf, &g_oneshot_argc, sizeof(int32_t));
-  char* wptr = buf + sizeof(int32_t)/sizeof(char);
+  size_t total_size = sizeof(int32_t);
+  if (g_oneshot_argc < 0) {
+    g_oneshot_argc = 0;
+  }
   for (int i = 0; i < g_oneshot_argc; i++) {
-    memcpy(wptr, g_oneshot_argv[i], strlen(g_oneshot_argv[i])+1);
-    wptr += strlen(g_oneshot_argv[i]) + 1;
+    if (g_oneshot_argv == NULL || g_oneshot_argv[i] == NULL) {
+      continue;
+    }
+    size_t arg_len = strlen(g_oneshot_argv[i]) + 1;
+    if (total_size > SIZE_MAX - arg_len) {
+      log_error("get_args_done_callback size overflow");
+      total_size = sizeof(int32_t);
+      g_oneshot_argc = 0;
+      break;
+    }
+    total_size += arg_len;
+  }
+  char *buf = malloc(total_size);
+  if (buf == NULL) {
+    log_error("get_args_done_callback malloc failed");
+    return;
+  }
+  memcpy(buf, &g_oneshot_argc, sizeof(int32_t));
+  char *wptr = buf + sizeof(int32_t);
+  for (int i = 0; i < g_oneshot_argc; i++) {
+    if (g_oneshot_argv == NULL || g_oneshot_argv[i] == NULL) {
+      continue;
+    }
+    size_t arg_len = strlen(g_oneshot_argv[i]) + 1;
+    memcpy(wptr, g_oneshot_argv[i], arg_len);
+    wptr += arg_len;
     free(g_oneshot_argv[i]);
   }
   free(g_oneshot_argv);
   g_oneshot_argv = NULL;
   g_oneshot_argc = 0;
-  comm_write_packet_to_cli(COMMAND_GET_ARGS_REPLY, buf, wptr - buf);
+  comm_write_packet_to_cli(COMMAND_GET_ARGS_REPLY, buf, (size_t)(wptr - buf));
   // free(a); //TODO!!!
 }
 
@@ -531,9 +679,23 @@ void get_args_done_callback(uv_async_t *a){
 int call_bootstrap_get_args(get_args_callback bootstrap_args_ready) {
   // async
   uv_async_t *s = malloc(sizeof(uv_async_t));
-  uv_async_init(uv_default_loop(), s, (uv_async_cb)bootstrap_args_ready);
+  if (s == NULL) {
+    log_error("malloc async callback failed");
+    return -1;
+  }
+  int rc = uv_async_init(uv_default_loop(), s, (uv_async_cb)bootstrap_args_ready);
+  if (rc != 0) {
+    free(s);
+    log_error("uv_async_init bootstrap args failed: %d", rc);
+    return -1;
+  }
   pthread_t p;
-  pthread_create(&p, NULL, (void*)bootstrap_get_args, s);
+  rc = pthread_create(&p, NULL, (void*)bootstrap_get_args, s);
+  if (rc != 0) {
+    free(s);
+    log_error("pthread_create bootstrap args failed: %d", rc);
+    return -1;
+  }
   pthread_detach(p);
   return 0;
 }
@@ -544,10 +706,25 @@ void server_handle_client_packet(int64_t type, char *buf, ssize_t len) {
       // from cli keyborad stream
       uv_write_t *req1 = malloc(sizeof(uv_write_t));
       uv_buf_t *b = malloc(sizeof(uv_buf_t));
+      if (req1 == NULL || b == NULL) {
+        free(req1);
+        free(b);
+        break;
+      }
       b->base = memdup(buf, len);
+      if (b->base == NULL) {
+        free(b);
+        free(req1);
+        break;
+      }
       b->len = len;
       req1->data = b;
-      uv_write(req1, (uv_stream_t *)&tty, b, 1, tty_write_cb_with_free);
+      int ret = uv_write(req1, (uv_stream_t *)&tty, b, 1, tty_write_cb_with_free);
+      if (ret != 0) {
+        free(((uv_buf_t *)(req1->data))->base);
+        free(req1->data);
+        free(req1);
+      }
       break;
     }
     case COMMAND_TTY_WIN_RESIZE: {
@@ -673,12 +850,14 @@ void server_handle_green_packet(char *buf, int size) {
   }
   if (size > 1 && buf[0] == 'B') {
     size_t result_len = 0;
-    char *result = base64_decode(buf + 1, size - 1, &result_len);
+    unsigned char *result =
+        base64_decode((const unsigned char *)(buf + 1), size - 1,
+                      &result_len);
     if (result_len == 0 || result == NULL) {
       log_error("found a error base64 [%*s]\n", size - 1, buf + 1);
       return;
     }
-    server_handle_agent_data(result, result_len);
+    server_handle_agent_data((char *)result, result_len);
     free(result);
   }
   return;

--- a/src/pipe.h
+++ b/src/pipe.h
@@ -18,11 +18,11 @@ extern int in_fd[2];
 extern int out_fd[2];
 extern void agent_write_data_to_server(char *buf, size_t s, bool autofree);
 extern void send_base64binary_to_agent(const char *buf, size_t size);
-void server();
+void server(int argc, char *argv[]);
 int libuv_add_vnet_notify();
 extern int vnet_notify_to_libuv(char *buf, size_t size);
-void comm_write_packet_to_cli(int64_t type, char *buf, size_t s);
-void comm_write_static_packet_to_cli(int64_t type, char *buf, size_t s);
+void comm_write_packet_to_cli(int64_t type, void *buf, size_t s);
+void comm_write_static_packet_to_cli(int64_t type, void *buf, size_t s);
 int push_data();
 int termtunnel_notify(void* s);
 #endif

--- a/src/portforward.c
+++ b/src/portforward.c
@@ -9,6 +9,7 @@
 
 #include <errno.h>
 #include <fcntl.h>
+#include <stdint.h>
 #include <pthread.h>
 #include <stdbool.h>
 #include <stdio.h>
@@ -49,7 +50,7 @@ typedef struct port_listen {
 } port_listen_t;
 
 static void portforward_static_server_request(void *p) {
-  int sd = (int)p;
+  int sd = (int)(intptr_t)p;
   vnet_setsocketdefaultopt(sd);
   char recv_buf[READ_CHUNK_SIZE];
   int n, nwrote;
@@ -241,10 +242,19 @@ static void loop_socket_to_lwipsocket(int *arg) {
 // 就直接启动两个线程即可。无法一起select。因为一个是lwip的fd一个是真实的fd。
 int pipe_lwip_socket_and_socket_pair(int lwip_fd, int fd) {
   int *array = (int *)malloc(2 * sizeof(int));
+  if (array == NULL) {
+    return -1;
+  }
   *(array) = lwip_fd;
   *(array + 1) = fd;
   pthread_t worker2;
-  pthread_create(&worker2, NULL, (void*)&loop_socket_to_lwipsocket, (void *)array);
+  int rc =
+      pthread_create(&worker2, NULL, (void *)&loop_socket_to_lwipsocket,
+                     (void *)array);
+  if (rc != 0) {
+    free(array);
+    return -1;
+  }
   loop_lwipsocket_to_socket((void *)array);
   pthread_join(worker2, NULL);
   log_info("lwip ip pair %d %d", lwip_fd, fd);
@@ -285,14 +295,44 @@ static void portforward_service_handler(port_listen_t *pe) {
     if ((new_sd = accept(listen_fd, NULL, NULL)) >= 0) {
       pthread_t *worker = (pthread_t *)malloc(sizeof(pthread_t));  // TODO(jdz)  free
       port_listen_t *child_pe = (port_listen_t *)malloc(sizeof(port_listen_t));
-      strcpy(child_pe->host, pe->host);
+      if (worker == NULL || child_pe == NULL) {
+        close(new_sd);
+        free(worker);
+        free(child_pe);
+        continue;
+      }
+      if (snprintf(child_pe->host, sizeof(child_pe->host), "%s", pe->host) >=
+          (int)sizeof(child_pe->host)) {
+        close(new_sd);
+        free(worker);
+        free(child_pe);
+        continue;
+      }
       child_pe->port = pe->port;
       child_pe->local_fd = new_sd;
       if (pe->port == 0) {  // socks/http proxy
-        pthread_create(worker, NULL, (void*)&portforward_transparent_server_pipe, (void *)child_pe);
+        int rc = pthread_create(worker, NULL,
+                                (void *)&portforward_transparent_server_pipe,
+                                (void *)child_pe);
+        if (rc != 0) {
+          close(new_sd);
+          free(worker);
+          free(child_pe);
+          continue;
+        }
       } else {
-        pthread_create(worker, NULL, (void*)&portforward_static_server_pipe, (void *)child_pe);
+        int rc = pthread_create(worker, NULL,
+                                (void *)&portforward_static_server_pipe,
+                                (void *)child_pe);
+        if (rc != 0) {
+          close(new_sd);
+          free(worker);
+          free(child_pe);
+          continue;
+        }
       } 
+      pthread_detach(*worker);
+      free(worker);
 
     } else {
       log_info("abort the accept");
@@ -344,7 +384,14 @@ int portforward_static_start(char *src_host, uint16_t src_port, char *dst_host,
   }
 
   port_listen_t *pe = (port_listen_t *)malloc(sizeof(port_listen_t));
-  strcpy(pe->host, dst_host);
+  if (pe == NULL) {
+    goto fail;
+  }
+  if (snprintf(pe->host, sizeof(pe->host), "%s", dst_host) >=
+      (int)sizeof(pe->host)) {
+    free(pe);
+    goto fail;
+  }
   pe->port = dst_port;
   pe->local_fd = sock;
   log_debug("portforward_static_start");

--- a/src/pty.c
+++ b/src/pty.c
@@ -148,8 +148,11 @@ int pty_run(int argc, char *argv[], tell_exitcode_callback *cb) {
 
   myself_fd = STDIN_FILENO;  // open("/dev/tty", O_RDONLY| O_NOCTTY);
   char *name = (char *)malloc(PATH_MAX);
-  ptsname_r(pty_fd, name, PATH_MAX);
   if (name == NULL) {
+    exit(EXIT_FAILURE);
+  }
+  if (ptsname_r(pty_fd, name, PATH_MAX) != 0) {
+    free(name);
     exit(EXIT_FAILURE);
   }
   // fcntl(pty_fd, F_SETFL, O_NONBLOCK);
@@ -177,9 +180,20 @@ int pty_run(int argc, char *argv[], tell_exitcode_callback *cb) {
 
     thread_pass_arg_t *temp =
         (thread_pass_arg_t *)malloc(sizeof(thread_pass_arg_t));
+    if (temp == NULL) {
+      free(name);
+      close(pty_fd);
+      return -1;
+    }
     temp->cb_func = cb;
     temp->process_pid = pid;
-    pthread_create(&thr, NULL, (void*)do_waitpid_wrap, temp);
+    int rc = pthread_create(&thr, NULL, (void *)do_waitpid_wrap, temp);
+    if (rc != 0) {
+      free(temp);
+      free(name);
+      close(pty_fd);
+      return -1;
+    }
     pthread_detach(thr);
   }
   free(name);

--- a/src/repl.c
+++ b/src/repl.c
@@ -38,10 +38,11 @@ int64_t ping_count = 0;
 
 int get_repl_stdout() { return out; }
 
-ssize_t expect_write(int fd, char *buf, size_t expect_size) {
+ssize_t expect_write(int fd, const void *buf, size_t expect_size) {
   size_t writebytes = 0;
+  const char *ptr = (const char *)buf;
   while (writebytes < expect_size) {
-    int wb = write(fd, buf + writebytes, expect_size - writebytes);
+    int wb = write(fd, ptr + writebytes, expect_size - writebytes);
     if (wb < 0) {
       if (errno == EINTR) {
         keyboard_break = true;
@@ -55,20 +56,26 @@ ssize_t expect_write(int fd, char *buf, size_t expect_size) {
 }
 
 // 一般会在 server_handle_client_packet进行处理
-void send_binary(int fd, int64_t type, char *addr, int len) {
+void send_binary(int fd, int64_t type, const void *addr, int len) {
   int ret = 0;
-  ret = expect_write(fd, &len, sizeof(int64_t));
+  int64_t len64 = len;
+  ret = expect_write(fd, &len64, sizeof(len64));
   CHECK(ret == sizeof(int64_t), "ret:%d sizeof(len):%d", ret, sizeof(int64_t));
   ret = expect_write(fd, &type, sizeof(type));
   CHECK(ret == sizeof(int64_t), "ret:%d sizeof(type):%d", ret, sizeof(int64_t));
-  ret = expect_write(fd, addr, len);
+  if (len > 0) {
+    ret = expect_write(fd, addr, len);
+  } else {
+    ret = 0;
+  }
   CHECK(ret == len, "ret:%d len:%d", ret, len);
 }
 
-ssize_t expect_read(int fd, char *buf, size_t expect_size) {
+ssize_t expect_read(int fd, void *buf, size_t expect_size) {
   size_t readbytes = 0;
+  char *ptr = (char *)buf;
   while (readbytes < expect_size) {
-    int rb = read(fd, buf + readbytes, expect_size - readbytes);
+    int rb = read(fd, ptr + readbytes, expect_size - readbytes);
     if (rb < 0) {
       if (errno == EINTR) {
         keyboard_break = true;
@@ -85,8 +92,11 @@ ssize_t expect_read(int fd, char *buf, size_t expect_size) {
 }
 
 void recv_data(int fd, int64_t *type, char **retbuf, int64_t *sz) {
+  const int64_t kMaxMessageSize = 64 * 1024 * 1024;  // defensive cap
   char *buf = (char *)malloc(sizeof(int64_t));
   *sz = 0;
+  *retbuf = NULL;
+  *type = 0;
   int a = expect_read(fd, buf, sizeof(int64_t));
   if (a == 0) {
     log_error("expect read 0");
@@ -95,6 +105,11 @@ void recv_data(int fd, int64_t *type, char **retbuf, int64_t *sz) {
   }
   CHECK(a == sizeof(int64_t), "a: %d", a);
   int64_t msg_size = *((int64_t *)buf);
+  if (msg_size < 0 || msg_size > kMaxMessageSize) {
+    log_error("invalid message size: %lld", msg_size);
+    free(buf);
+    return;
+  }
   a = expect_read(fd, buf, sizeof(int64_t));
   if (a == 0) {
     free(buf);
@@ -102,7 +117,13 @@ void recv_data(int fd, int64_t *type, char **retbuf, int64_t *sz) {
   }
   *type = *((int64_t *)buf);
   if (msg_size != 0) {
-    buf = realloc(buf, msg_size);
+    char *new_buf = realloc(buf, msg_size);
+    if (new_buf == NULL) {
+      free(buf);
+      log_error("realloc failed for message size: %lld", msg_size);
+      return;
+    }
+    buf = new_buf;
   }
   a = expect_read(fd, buf, msg_size);
   CHECK(a == msg_size, "a: %d,msg_size: %lld\n", a, msg_size);
@@ -165,7 +186,7 @@ void test_split(const char *s) {
   strcpy(buf, s);
   argc = split(buf, argv, 20);
   printf("input: '%s'\n", s);
-  for (i = 0; i < argc; i++) printf("[%u] '%s'\n", i, argv[i]);
+  for (i = 0; i < argc; i++) printf("[%zu] '%s'\n", i, argv[i]);
 }
 
 void completion(const char *buf, linenoiseCompletions *lc) {
@@ -212,14 +233,24 @@ int hello_func(int argc, char **argv) {
     printf("hello [message]\n");
     return 0;
   }
+  return 0;
 }
 
 file_exchange_intent_t *new_file_exchange_intent(char *src, char *dst,
                                                  int trans_mode) {
   file_exchange_intent_t *tmp =
       (file_exchange_intent_t *)malloc(sizeof(file_exchange_intent_t));
-  strcpy(tmp->src_path, src);
-  strcpy(tmp->dst_path, dst);
+  if (tmp == NULL) {
+    return NULL;
+  }
+  if (snprintf(tmp->src_path, sizeof(tmp->src_path), "%s", src) >=
+          (int)sizeof(tmp->src_path) ||
+      snprintf(tmp->dst_path, sizeof(tmp->dst_path), "%s", dst) >=
+          (int)sizeof(tmp->dst_path)) {
+    log_error("file path too long");
+    free(tmp);
+    return NULL;
+  }
   tmp->trans_mode = trans_mode;
   return tmp;
 }
@@ -230,9 +261,18 @@ port_forward_intent_t *new_port_forward_intent(int forward_type, char *src_host,
                                                uint16_t dst_port) {
   port_forward_intent_t *tmp =
       (port_forward_intent_t *)malloc(sizeof(port_forward_intent_t));
+  if (tmp == NULL) {
+    return NULL;
+  }
   tmp->forward_type = forward_type;
-  strcpy(tmp->src_host, src_host);
-  strcpy(tmp->dst_host, dst_host);
+  if (snprintf(tmp->src_host, sizeof(tmp->src_host), "%s", src_host) >=
+          (int)sizeof(tmp->src_host) ||
+      snprintf(tmp->dst_host, sizeof(tmp->dst_host), "%s", dst_host) >=
+          (int)sizeof(tmp->dst_host)) {
+    log_error("host too long");
+    free(tmp);
+    return NULL;
+  }
   tmp->src_port = src_port;
   tmp->dst_port = dst_port;
   return tmp;
@@ -257,6 +297,10 @@ int portforward_func(int argc, char **argv) {
 
   port_forward_intent_t *a = new_port_forward_intent(
       forward_type, src_host, src_port, dst_host, dst_port);
+  if (a == NULL) {
+    printf("invalid forward args\n");
+    return 0;
+  }
   send_binary(out, COMMAND_PORT_FORWARD, a, sizeof(port_forward_intent_t));
   free(a);
 
@@ -267,7 +311,7 @@ int portforward_func(int argc, char **argv) {
   if (type == COMMAND_RETURN) {
     printf("%s", buf);
   } else {
-    printf("type: %d", type);
+    printf("type: %lld", type);
   }
   free(buf);
 
@@ -277,6 +321,10 @@ int portforward_func(int argc, char **argv) {
 
 int upload_func(int argc, char **argv) {
   char *url = (char *)malloc(PATH_MAX);
+  if (url == NULL) {
+    printf("malloc failed\n");
+    return 0;
+  }
   if (argc == 1) {
     // static
     char *_url = tinyfd_openFileDialog("Upload", "", 0, NULL,
@@ -286,15 +334,27 @@ int upload_func(int argc, char **argv) {
       printf("Path not exist\n");
       return 0;
     }
-    strcpy(url, _url);
+    if (snprintf(url, PATH_MAX, "%s", _url) >= PATH_MAX) {
+      free(url);
+      printf("Path too long\n");
+      return 0;
+    }
   } else {
-    strcpy(url, argv[1]);
+    if (snprintf(url, PATH_MAX, "%s", argv[1]) >= PATH_MAX) {
+      free(url);
+      printf("Path too long\n");
+      return 0;
+    }
   }
   printf("upload %s\n", url);
   char *tmp = strdup(url);
   char *bname = basename(tmp);
   file_exchange_intent_t *a =
       new_file_exchange_intent(url, bname, TRANS_MODE_SEND_FILE);
+  if (a == NULL) {
+    free(url);
+    return 0;
+  }
   free(tmp);
 
   send_binary(out, COMMAND_FILE_EXCHANGE, a, sizeof(file_exchange_intent_t));
@@ -309,6 +369,10 @@ int download_func(int argc, char **argv) {
     return 0;
   }
   char *url = (char *)malloc(PATH_MAX);
+  if (url == NULL) {
+    printf("malloc failed\n");
+    return 0;
+  }
 
   // select folder to download
   if (argc == 2) {
@@ -319,7 +383,11 @@ int download_func(int argc, char **argv) {
       printf("Path not exist\n");
       return 0;
     }
-    strcpy(url, _url);
+    if (snprintf(url, PATH_MAX, "%s", _url) >= PATH_MAX) {
+      free(url);
+      printf("Path too long\n");
+      return 0;
+    }
   } else {
     // TODO 后续允许自行制定文件夹
     printf("download [remote_file]\n");
@@ -331,11 +399,22 @@ int download_func(int argc, char **argv) {
   char *bname = basename(tmp_pf);
   file_exchange_intent_t *a =
       new_file_exchange_intent(src, url, TRANS_MODE_RECV_FILE);
+  if (a == NULL) {
+    free(url);
+    free(tmp_pf);
+    return 0;
+  }
 
-  
-  strcat(a->dst_path, "/"); // linux without /
+  if (snprintf(a->dst_path, sizeof(a->dst_path), "%s/%s", url, bname) >=
+      (int)sizeof(a->dst_path)) {
+    printf("Path too long\n");
+    free(url);
+    free(a);
+    free(tmp_pf);
+    return 0;
+  }
+  // linux without /
   // TODO macos ok, linux is ok?
-  strcat(a->dst_path, bname);
   send_binary(out, COMMAND_FILE_EXCHANGE, a, sizeof(file_exchange_intent_t));
   free(url);
   free(a);

--- a/src/repl.h
+++ b/src/repl.h
@@ -19,5 +19,5 @@ extern void interact_run(int _in, int _out);
 extern int get_repl_stdout();
 
 extern void oneshot_run(int _in, int _out);
-extern void send_binary(int fd, int64_t type, char *addr, int len);
+extern void send_binary(int fd, int64_t type, const void *addr, int len);
 #endif

--- a/src/socksproxy.c
+++ b/src/socksproxy.c
@@ -77,19 +77,25 @@ int readn(int fd, void *buf, int n) {
 
 int readtocharR(int fd, char *buf, int bufsize) {
   int readbytes = 0;
-  char* last;
-  do {
-      int n = lwip_read(fd, buf + readbytes, 1);
+  while (readbytes < bufsize) {
+    int n = lwip_read(fd, buf + readbytes, 1);
+    if (n < 0) {
       if (errno == EINTR || errno == EAGAIN) {
         continue;
       }
-      if (n <= 0) {
-        return 0;
-      }
-      readbytes += 1;
-      last = buf + readbytes - 1;
-    } while (strncmp(last-3 ,"\r\n\r\n", 4)!=0 && readbytes < bufsize);
-    return readbytes;
+      return -1;
+    }
+    if (n == 0) {
+      return 0;
+    }
+    readbytes += n;
+    // Require at least 4 bytes before checking CRLFCRLF to avoid OOB access.
+    if (readbytes >= 4 &&
+        memcmp(buf + readbytes - 4, "\r\n\r\n", 4) == 0) {
+      break;
+    }
+  }
+  return readbytes;
 }
 
 int report_error_to_client(int fd, char *message) {
@@ -98,7 +104,7 @@ int report_error_to_client(int fd, char *message) {
   }
   char buffer[512];
   snprintf(buffer, sizeof(buffer), "HTTP/1.1 500 Internal Server Error %s\r\n\r\n", message);
-  lwip_writen(fd, buffer, strlen(buffer));
+  return lwip_writen(fd, buffer, strlen(buffer));
 }
 
 int http_proxy(int fd, char *prefetch_data, int prefetch_data_size) {
@@ -108,17 +114,23 @@ int http_proxy(int fd, char *prefetch_data, int prefetch_data_size) {
   char *url;
   char host[128];
   char *h, *rest;
+  char *host_end = host + sizeof(host) - 1;
   uint16_t port;
   char cmd[16];
   int read_bytes = 0;
   char *header = NULL;
   // char *prefetch_data, prefetch_data_size);
   //  TODO read to HTTP1.1
+  if (prefetch_data_size < 0 ||
+      prefetch_data_size >= (int)sizeof(buffer) - 1) {
+    log_info("invalid prefetch size: %d", prefetch_data_size);
+    return 0;
+  }
   memcpy(buffer, prefetch_data, prefetch_data_size);
   //int n = lwip_read(fd, buffer + prefetch_data_size,
   //              sizeof(buffer) - prefetch_data_size);
   int n = readtocharR(fd, buffer + prefetch_data_size,
-                sizeof(buffer) - prefetch_data_size);
+                      sizeof(buffer) - 1 - prefetch_data_size);
   header = buffer;
   read_bytes = n + prefetch_data_size;
   if (n < 1) {
@@ -128,6 +140,7 @@ int http_proxy(int fd, char *prefetch_data, int prefetch_data_size) {
     }
     return 0;
   }
+  buffer[read_bytes] = '\0';
   log_info("prefetch %d bytes", n);
   int i = 0;
   for (i = 0; i < 15; i++)
@@ -149,14 +162,28 @@ int http_proxy(int fd, char *prefetch_data, int prefetch_data_size) {
     // CONNECT g.cn:443 HTTP/1.1
     url = buffer + 8;  //"CONNECT "
     h = host;
-    for (; *url && (*url != ':') && (*url != '/'); url++) *(h++) = *url;
+    for (; *url && (*url != ':') && (*url != '/') && (*url != ' ') &&
+           (h < host_end);
+         url++)
+      *(h++) = *url;
     *h = '\0';
+    if (*url == ' ' || *url == '\0') {
+      report_error_to_client(fd, "invalid CONNECT request");
+      lwip_close(fd);
+      return 0;
+    }
     if (*url == ':') {
       port = strtoul(url + 1, NULL, 0);
-      for (; *url != '/'; url++)
-        ;
+      while (*url && *url != '/' && *url != ' ' && *url != '\r' &&
+             *url != '\n')
+        url++;
     } else {
       port = httpport;
+    }
+    if (*url == '\0' || *url == '\r' || *url == '\n') {
+      report_error_to_client(fd, "invalid CONNECT request");
+      lwip_close(fd);
+      return 0;
     }
     for (rest = url; *rest && (*rest != '\n'); rest++);
     if (*rest) {
@@ -165,16 +192,35 @@ int http_proxy(int fd, char *prefetch_data, int prefetch_data_size) {
     }
   } else {
     //GET http://g.cn:80
-    for (url = buffer; *url && (*url != '/'); url++);
+    for (url = buffer; *url && (*url != '/'); url++)
+      ;
+    if (*url == '\0') {
+      report_error_to_client(fd, "invalid HTTP request");
+      lwip_close(fd);
+      return 0;
+    }
     url += 2;
     h = host;
-    for (; *url && (*url != ':') && (*url != '/'); url++) *(h++) = *url;
+    for (; *url && (*url != ':') && (*url != '/') && (h < host_end); url++)
+      *(h++) = *url;
     *h = '\0';
+    if (*url == '\0') {
+      report_error_to_client(fd, "invalid HTTP request");
+      lwip_close(fd);
+      return 0;
+    }
     if (*url == ':') {
       port = strtoul(url + 1, NULL, 0);
-      for (; *url != '/'; url++);
+      while (*url && *url != '/' && *url != ' ' && *url != '\r' &&
+             *url != '\n')
+        url++;
     } else {
       port = httpport;
+    }
+    if (*url == '\0' || *url == '\r' || *url == '\n') {
+      report_error_to_client(fd, "invalid HTTP request");
+      lwip_close(fd);
+      return 0;
     }
     for (rest = url; *rest && (*rest != '\n'); rest++);
     if (*rest) {
@@ -207,7 +253,7 @@ int http_proxy(int fd, char *prefetch_data, int prefetch_data_size) {
     return 0;
   }
   if (strcmp(cmd, "CONNECT") != 0) {
-    sprintf(buf2, "%s %s\n", cmd, url);
+    snprintf(buf2, sizeof(buf2), "%s %s\n", cmd, url);
     if (write(rfd, buf2, strlen(buf2)) < 1) {
       lwip_close(fd);
       close(rfd);
@@ -236,6 +282,7 @@ int http_proxy(int fd, char *prefetch_data, int prefetch_data_size) {
 
   close(rfd);
   lwip_close(fd);
+  return 0;
 }
 
 void app_thread_exit(int ret, int fd) {
@@ -485,7 +532,7 @@ void socks4_send_response(int fd, int status) {
 }
 
 void *app_thread_process(void *fd) {
-  int net_fd = (int)fd;
+  int net_fd = (int)(intptr_t)fd;
   vnet_setsocketdefaultopt(net_fd);
   int version = 0;
   int inet_fd = -1;

--- a/src/utils.c
+++ b/src/utils.c
@@ -30,7 +30,7 @@
 struct termios ttystate_backup;
 static bool _stdin_is_raw = false;
 
-const char *green_encode(const char *buf, int len, int *result_len) {
+char *green_encode(const char *buf, int len, int *result_len) {
   const char *prefix = "\e[32;42m";
   const int prefix_len = sizeof("\e[32;42m") - 1;
   const char *postfix = "\e[0m";
@@ -147,4 +147,3 @@ char* safe_gethostbyname(char *host, uint16_t port) {
     }
     return NULL;
 }
-

--- a/src/utils.h
+++ b/src/utils.h
@@ -28,7 +28,7 @@ extern int writen(int fd, void *buf, int n);
 extern void set_stdin_raw();
 extern void restore_stdin();
 extern void *memdup(const void *src, size_t n);
-extern const char *green_encode(const char *buf, int len, int *result_len);
+extern char *green_encode(const char *buf, int len, int *result_len);
 
 
 extern void utils_counter_init(struct counter_t *c);

--- a/src/vnet.c
+++ b/src/vnet.c
@@ -13,6 +13,7 @@
 #include "lwip/tcpip.h"
 
 #include <fcntl.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -118,7 +119,7 @@ int vnet_listen_at(uint16_t port, void *cb, char* thread_desc) {
     if ((new_sd = lwip_accept(sock, (struct sockaddr *)&remote, (socklen_t *)&size)) >= 0) {
       log_info("new tcp");
       sys_thread_new(thread_desc, cb,
-                     (void *)new_sd, DEFAULT_THREAD_STACKSIZE,
+                     (void *)(intptr_t)new_sd, DEFAULT_THREAD_STACKSIZE,
                      DEFAULT_THREAD_PRIO);
     } else {
       log_info("abort %d %d %s", new_sd, errno, strerror(errno));
@@ -190,7 +191,7 @@ int vnet_send(int s, const void *data, size_t size) {
   return lwip_send(s, data, size, 0);
 }
 
-int vnet_recv(int s, const void *data, size_t size) {
+int vnet_recv(int s, void *data, size_t size) {
   return lwip_recv(s, data, size, 0);
 }
 

--- a/src/vnet.h
+++ b/src/vnet.h
@@ -15,7 +15,7 @@ void vnet_data_income(char *buf, size_t size);
 void vnet_deinit();
 int vnet_tcp_connect(uint16_t port);
 int vnet_send(int s, const void *data, size_t size);
-int vnet_recv(int s, const void *data, size_t size);
+int vnet_recv(int s, void *data, size_t size);
 int vnet_listen_at(uint16_t port, void *cb,char* thread_desc);
 int vnet_close(int s);
 int lwip_writen(int fd, void *buf, int n);

--- a/thirdparty/libuv/CMakeLists.txt
+++ b/thirdparty/libuv/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.5)
 project(libuv LANGUAGES C)
 
 cmake_policy(SET CMP0057 NEW) # Enable IN_LIST operator


### PR DESCRIPTION
This change tightens allocation checks, bounded copies, message-size validation, and libuv error handling across the agent, REPL, forwarding, and file-transfer paths. It also fixes pointer-width casts and thread startup failure handling so the tunnel fails closed instead of corrupting memory or leaking worker state.

Constraint: Must preserve the existing CLI and framing behavior while hardening failure paths
Rejected: Rewrite the transport pipeline around new abstractions | too risky for a bugfix pass
Confidence: medium
Scope-risk: moderate
Reversibility: clean
Directive: Keep protocol framing limits and fixed-size path buffers aligned across agent, repl, and forwarding code
Tested: cmake -S . -B build && cmake --build build
Not-tested: End-to-end remote tunnel, file transfer, and port-forward sessions against a live peer